### PR TITLE
fix enum type warning in  milter/manager/milter-manager-leader.c

### DIFF
--- a/milter/manager/milter-manager-leader.c
+++ b/milter/manager/milter-manager-leader.c
@@ -149,7 +149,7 @@ milter_manager_leader_init (MilterManagerLeader *leader)
     priv->configuration = NULL;
     priv->client_context = NULL;
     priv->children = NULL;
-    priv->state = MILTER_SERVER_CONTEXT_STATE_START;
+    priv->state = MILTER_MANAGER_LEADER_STATE_START;
     priv->sent_end_of_message = FALSE;
     priv->launcher_read_channel = NULL;
     priv->launcher_write_channel = NULL;


### PR DESCRIPTION
the compiler warns that enumeration type is incorrect at:

> milter-manager-leader.c:152:19: warning: implicit conversion from enumeration type 'MilterServerContextState' to different enumeration type 'MilterManagerLeaderState' [-Wconversion]

the change is subtle :)
