### PR TITLE
test-client-context fails

### DIFF
--- a/binding/ruby/test/client/test-client-context.rb
+++ b/binding/ruby/test/client/test-client-context.rb
@@ -230,7 +230,7 @@ class TestClientContext < Test::Unit::TestCase
                      [received_name, received_name.encoding,
                       received_value, received_value.encoding])
       else
-        assert_equal([name, value], [receive_name, received_value])
+        assert_equal([name, value], [received_name, received_value])
       end
     end
 


### PR DESCRIPTION
TestClientContext::TestSignal fails because of typo

> Error: test_header(TestClientContext::TestSignal)
> NameError: undefined local variable or method `receive_name' for #<TestClientContext::TestSignal:0x8037a1100>
> /usr/ports/mail/milter-manager/work/milter-manager-1.8.4/binding/ruby/test/client/test-client-context.rb:233:in`test_header'
>      230:                      [received_name, received_name.encoding,
>      231:                       received_value, received_value.encoding])
>      232:       else
>   => 233:         assert_equal([name, value], [receive_name, received_value])
>      234:       end
>      235:     end
>      236: 
