### PR TITLE
Fix wrong path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,8 +221,8 @@ bindingdir='$(pkglibdir)/binding'
 expanded_bindingdir="${milter_manager_libdir}/${PACKAGE_NAME}/binding"
 binding_extdir='$(bindingdir)/ext'
 binding_libdir='$(bindingdir)/lib'
-expanded_binding_extdir="${expanded_bindingdir}/ext"
-expanded_binding_libdir="${expanded_bindingdir}/lib"
+expanded_binding_extdir="${expanded_bindingdir}/ruby/ext"
+expanded_binding_libdir="${expanded_bindingdir}/ruby/lib"
 AC_SUBST(bindingdir)
 AC_SUBST(binding_extdir)
 AC_SUBST(binding_libdir)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -149,10 +149,10 @@ MAINTAINERCLEANFILES = $(dist_man1_MANS) $(dist_ja_man1_mans)
 SUFFIXES = .rd .man .rd .jman .svg .png
 
 .rd.man:
-	$(RUBY) -I $(CUTTER_SOURCE_PATH)/misc $(RD2) -r rd2man-lib $< > $@
+	$(RUBY) -I $(CUTTER_SOURCE_PATH)/misc $(RD2) -r rd/rd2man-lib $< > $@
 
 .rd.jman: # dirty...
-	$(RUBY) -I $(CUTTER_SOURCE_PATH)/misc $(RD2) -r rd2man-lib $<.ja > $@
+	$(RUBY) -I $(CUTTER_SOURCE_PATH)/misc $(RD2) -r rd/rd2man-lib $<.ja > $@
 
 .svg.png:
 	inkscape --export-png $@ $<


### PR DESCRIPTION
`make install` 時に下記のエラーが出ていた問題を修正しました。

`expanded_binding_extdir`と`expanded_binding_libdir`のパスが間違っている
```
make[4]: ディレクトリ `/home/t-maki/ruby/milter-manager/binding/ruby/glib-2.2.5/ext/glib2' に入ります     
/usr/bin/install -c -m 644 /home/t-maki/ruby/milter-manager/binding/ruby/glib-2.2.5/ext/glib2/rbglib.h /opt/mim/lib/milter-manager/binding/ext                                                                      
/usr/bin/install: 通常ファイル `/opt/mim/lib/milter-manager/binding/ext' を作成できません: そのようなファ イルやディレクトリはありません                                                                            
make[4]: *** [install-headers] エラー 1              
``` 
`rd2man-lib`のパスが間違っている
```
/home/t-maki/.rbenv/versions/2.2.2/bin/ruby -I /misc /home/t-maki/.rbenv/versions/2.2.2/bin/rd2 -r rd2man-lib milter-test-server.rd.ja > milter-test-server.jman
/home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- rd2man-lib (LoadError)                                                              
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rdtool-0.6.38/bin/rd2:96:in `block (2 levels) in <top (required)>'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1427:in `call'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1427:in `block in parse_in_order'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1383:in `catch'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1383:in `parse_in_order'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1377:in `order!'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1469:in `permute!'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1491:in `parse!'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/2.2.0/optparse.rb:1953:in `parse!'
        from /home/t-maki/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rdtool-0.6.38/bin/rd2:173:in `<top (required)>'
        from /home/t-maki/.rbenv/versions/2.2.2/bin/rd2:23:in `load'
        from /home/t-maki/.rbenv/versions/2.2.2/bin/rd2:23:in `<main>'
make[3]: *** [milter-test-server.jman] エラー 1
```
