### PR TITLE
binding ruby: Suppress -Wsign-compare warning

### DIFF
--- a/binding/ruby/ext/core/rb-milter-socket-address.c
+++ b/binding/ruby/ext/core/rb-milter-socket-address.c
@@ -160,7 +160,7 @@ unix_pack (VALUE self)
 {
     VALUE path;
     struct sockaddr_un address;
-    int path_length;
+    unsigned int path_length;
 
     path = rb_iv_get(self, "@path");
 


### PR DESCRIPTION
```log
rb-milter-socket-address.c: In function 'unix_pack':
rb-milter-socket-address.c:171:21: warning: comparison between signed
and unsigned integer expressions [-Wsign-compare]
     if (path_length > sizeof(address.sun_path))
	                      ^
```

path_length seems to be always greater than or equals 0.