### PR TITLE
core test: Try to use "ip6-localhost" in parse_connection_spec_inet6 test

### DIFF
--- a/test/core/test-connection.c
+++ b/test/core/test-connection.c
@@ -356,7 +356,7 @@ data_parse_connection_spec_inet6 (void)
                                NULL),
                  test_data_free,
                  "full - host name",
-                 test_data_new("inet6:9999@localhost",
+                 test_data_new("inet6:9999@ip6-localhost",
                                sockaddr_in6_new(9999, "::1"),
                                NULL),
                  test_data_free,


### PR DESCRIPTION
Because simply using "localhost" in parse_connection_spec_inet6 test
causes following error:

```log
Failure: test_parse_connection_spec_inet6 (full - host name)
expected: <error> is NULL
  actual: <milter-connection-error-quark:0: invalid host address:
  <inet6:9999@localhost>: <localhost>: <名前またはサービスが不明です>>
  /home/hhatake/Github/milter-manager/test/core/test-connection.c:402:
  test_parse_connection_spec_inet6(): gcut_assert_error(error, )
```

And /etc/hosts says IPv6 version of "localhost" nodename is:

```bash
% cat /etc/hosts
...
::1     ip6-localhost ip6-loopback
...
```

But I do not have enough confidence that this fix is correct....