### PR TITLE
doc: Remove installation manual for Ubuntu Saucy (13.10)

### DIFF
--- a/doc/install-to-ubuntu.rd
+++ b/doc/install-to-ubuntu.rd
@@ -28,18 +28,6 @@ content:
 
   deb http://archive.ubuntu.com/ubuntu precise-backports main universe
 
-=== For Saucy Salamander
-
-/etc/apt/sources.list.d/milter-manager.list:
-  deb http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-  deb-src http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-
-If you don't enable the official backport repository, you need to
-create /etc/apt/sources.list.d/backports.list with the following
-content:
-
-  deb http://archive.ubuntu.com/ubuntu saucy-backports main universe
-
 === For Trusty Tahr
 
 /etc/apt/sources.list.d/milter-manager.list:

--- a/doc/install-to-ubuntu.rd.ja
+++ b/doc/install-to-ubuntu.rd.ja
@@ -28,17 +28,6 @@ milter managerのサイトでは以下のUbuntu用debパッケージを提供し
 
   deb http://jp.archive.ubuntu.com/ubuntu precise-backports main universe
 
-=== Saucy Salamanderの場合
-
-/etc/apt/sources.list.d/milter-manager.list:
-  deb http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-  deb-src http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-
-もし、まだバックポートリポジトリを有効にしていない場合は以下のような内
-容の/etc/apt/sources.list.d/backports.listを作成して有効にします。
-
-  deb http://jp.archive.ubuntu.com/ubuntu saucy-backports main universe
-
 === Trusty Tahrの場合
 
 /etc/apt/sources.list.d/milter-manager.list:

--- a/doc/upgrade-on-ubuntu.rd
+++ b/doc/upgrade-on-ubuntu.rd
@@ -33,12 +33,6 @@ Please update your source.list as soon as possible.
   deb http://sourceforge.net/projects/milter-manager/files/ubuntu/stable precise universe
   deb-src http://sourceforge.net/projects/milter-manager/files/ubuntu/stable precise universe
 
-=== For Saucy Salamander
-
-/etc/apt/sources.list.d/milter-manager.list:
-  deb http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-  deb-src http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-
 === For Trusty Tahr
 
 /etc/apt/sources.list.d/milter-manager.list:

--- a/doc/upgrade-on-ubuntu.rd.ja
+++ b/doc/upgrade-on-ubuntu.rd.ja
@@ -32,12 +32,6 @@ sources.list に指定する URI を変更しました。しばらくは以前�
   deb http://sourceforge.net/projects/milter-manager/files/ubuntu/stable precise universe
   deb-src http://sourceforge.net/projects/milter-manager/files/ubuntu/stable precise universe
 
-=== Saucy Salamanderの場合
-
-/etc/apt/sources.list.d/milter-manager.list:
-  deb http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-  deb-src http://sourceforge.net/projects/milter-manager/files/ubuntu/stable saucy universe
-
 === Trusty Tahrの場合
 
 /etc/apt/sources.list.d/milter-manager.list:


### PR DESCRIPTION
Milter-manager already didn't support this version of Ubuntu.