### PR TITLE
binding ruby: Add missing pkg-config.rb

### DIFF
--- a/binding/ruby/Makefile.am
+++ b/binding/ruby/Makefile.am
@@ -262,6 +262,7 @@ ruby_glib2_latest_files =						\
 	glib-2.2.5/lib/gnome2/rake/windows-binary-build-task.rb		\
 	glib-2.2.5/lib/gnome2/rake/windows-binary-download-task.rb	\
 	glib-2.2.5/lib/mkmf-gnome2.rb					\
+	glib-2.2.5/lib/pkg-config.rb					\
 	glib-2.2.5/patches/glib-2.38.2-add-missing-exeext.diff		\
 	glib-2.2.5/sample/bookmarkfile.rb				\
 	glib-2.2.5/sample/idle.rb					\


### PR DESCRIPTION
Because following error occurred while rpm building:

```log
configure: checking bundled Ruby/GLib2 2.2.5
/usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- pkg-config (LoadError)
	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/milter-manager-build/rpm/BUILD/milter-manager-2.0.5/binding/ruby/glib-2.2.5/lib/mkmf-gnome2.rb:14:in `<top (required)>'
	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/milter-manager-build/rpm/BUILD/milter-manager-2.0.5/binding/ruby/glib-2.2.5/ext/glib2/extconf.rb:15:in `<main>'
configure: error: Ruby/GLib2 is required.
error: Bad exit status from /var/tmp/rpm-tmp.d9wTF6 (%build)
```

This bug was introduced in 3541714c3f3508e8dcaf76bcc9db62bbaa03800b.