### PR TITLE
package yum rpm: Bundle Ruby 2.2.3 in CentOS6

### DIFF
--- a/package/rpm/centos/milter-manager.spec.in
+++ b/package/rpm/centos/milter-manager.spec.in
@@ -1,7 +1,7 @@
 %if 0%{?centos} == 6
-%define ruby_command ruby2.1
-%define ruby_package ruby2.1
-%define ruby_build_requires ruby2.1
+%define ruby_command ruby2.2
+%define ruby_package ruby2.2
+%define ruby_build_requires ruby2.2
 %else
 %define ruby_command ruby
 %define ruby_package ruby

--- a/package/yum/build-rpm.sh
+++ b/package/yum/build-rpm.sh
@@ -123,9 +123,9 @@ fi
 
 case $distribution_version in
     6.*)
-        if ! rpm -q ruby2.1 > /dev/null 2>&1; then
-            yum install -y wget libyaml libyaml-devel
-            yum install -y $(grep BuildRequires: /tmp/ruby21.spec | cut -d: -f2)
+        if ! rpm -q ruby2.2 > /dev/null 2>&1; then
+            yum install -y wget
+            yum install -y $(grep BuildRequires: /tmp/ruby22.spec | cut -d: -f2)
             cat <<EOF > $BUILD_RUBY_SCRIPT
 if [ ! -f ~/.rpmmacros ]; then
     cat <<EOM > ~/.rpmmacros
@@ -142,10 +142,10 @@ mkdir -p rpm/SRPMS
 
 case $distribution_version in
   6.*)
-    if ! rpm -q ruby2.1 > /dev/null 2>&1; then
-      wget http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz -P rpm/SOURCES
-      cp -a /tmp/ruby21.spec rpm/SPECS/ruby21.spec
-      rpmbuild -ba rpm/SPECS/ruby21.spec
+    if ! rpm -q ruby2.2 > /dev/null 2>&1; then
+      wget http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz -P rpm/SOURCES
+      cp -a /tmp/ruby22.spec rpm/SPECS/ruby22.spec
+      rpmbuild -ba rpm/SPECS/ruby22.spec
     fi
     ;;
 esac

--- a/package/yum/vendor/ruby22.spec
+++ b/package/yum/vendor/ruby22.spec
@@ -1,6 +1,6 @@
-%define rubyver         2.1.5
+%define rubyver         2.2.3
 
-Name:           ruby2.1
+Name:           ruby2.2
 Version:        %{rubyver}
 Release:        2%{?dist}
 License:        BSD
@@ -10,7 +10,7 @@ BuildRequires:  readline readline-devel ncurses ncurses-devel gdbm gdbm-devel gl
 Source0:        ftp://ftp.ruby-lang.org/pub/ruby/ruby-%{rubyver}.tar.gz
 Summary:        An interpreter of object-oriented scripting language
 Group:          Development/Languages
-Provides: ruby(abi) = 2.1
+Provides: ruby(abi) = 2.2
 Conflicts: ruby1.9
 
 %description
@@ -32,8 +32,8 @@ export CFLAGS="$RPM_OPT_FLAGS -Wall -fno-strict-aliasing"
   --without-tk \
   --includedir=%{_includedir}/ruby \
   --libdir=%{_libdir} \
-  --with-soname=ruby-2.1 \
-  --program-suffix=2.1
+  --with-soname=ruby-2.2 \
+  --program-suffix=2.2
 
 make %{?_smp_mflags}
 
@@ -56,6 +56,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Thu Nov 5 2014 Hiroshi Hatake <hatake@clear-code.com> - 2.2.3
+- Update ruby version to 2.2.3
+
 * Thu Nov 27 2014 Kenji Okimoto <okimoto@clear-code.com> - 2.1.5
 - Update ruby version to 2.1.5
 


### PR DESCRIPTION
In my chrooted CentOS 6 environment, creating Ruby 2.2.3 rpms and installing these rpms works fine.