### PR TITLE
doc: Add note for using rbenv

### DIFF
--- a/doc/release.rd.ja
+++ b/doc/release.rd.ja
@@ -11,6 +11,11 @@ rbenv を使用している場合は、以下のように ruby コマンドと r
 パスを指定する。rbenv を使用していない場合は各コマンドのパスを自動検出
 するようになっている。
 
+rbenvでRubyを入れる場合は、RUBY_CONFIGURE_OPTS="--enable-shared" を指定してインストールしておく必要がある。
+
+例:
+  % RUBY_CONFIGURE_OPTS="--enable-shared" rbenv install 2.2.3
+
 TODO: 手順を整理する。
 NOTE: apt で入れるパッケージと gem で入れるパッケージが被っている。。。
 


### PR DESCRIPTION
`rbenv` does not create `ruby.so` by default.