### PR TITLE
package yum: Force rpm_dir arch to i686 in centos-6-i386 build

### DIFF
--- a/package/yum/build-in-chroot.sh
+++ b/package/yum/build-in-chroot.sh
@@ -90,7 +90,11 @@ build()
     build_user=${PACKAGE}-build
     build_user_dir=${base_dir}/home/${build_user}
     rpm_base_dir=${build_user_dir}/rpm
-    rpm_dir=${rpm_base_dir}/RPMS/${architecture}
+    if [ $architecture = "x86_64" ]; then
+        rpm_dir=${rpm_base_dir}/RPMS/${architecture}
+    else
+        rpm_dir=${rpm_base_dir}/RPMS/i686
+    fi
     srpm_dir=${rpm_base_dir}/SRPMS
     pool_base_dir=${distribution}/${distribution_version}
     if test "${HAVE_DEVELOPMENT_BRANCH}" = "yes"; then


### PR DESCRIPTION
Because following error occurred w/o this patch:

```log
cp:
`/var/lib/chroot/centos-6-i386/home/milter-manager-build/rpm/RPMS/i386/*.rpm'
を stat できません: そのようなファイルやディレクトリはありません
Failed cp -p
/var/lib/chroot/centos-6-i386/home/milter-manager-build/rpm/RPMS/i386/*.rpm
centos/6/stable/i386/Packages
Makefile:597: recipe for target 'build-in-chroot' failed
make: *** [build-in-chroot] Error 1
```

But I think that this fix is too ad-hoc....