### PR TITLE
redhat systemd: Add systemd unit file for CentOS7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1003,6 +1003,8 @@ AC_CONFIG_FILES([Makefile
 		 data/smf/manifest/Makefile
 		 data/smf/manifest/milter-manager.xml
 		 data/smf/method/Makefile
+		 data/systemd/Makefile
+		 data/systemd/redhat/Makefile
 		 package/solaris/Makefile
 		 package/solaris/prototypes/Makefile
 		 package/solaris/prototypes/milter-manager/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -7,7 +7,8 @@ SUBDIRS =			\
 	init.d			\
 	cron.d			\
 	munin			\
-	smf
+	smf			\
+	systemd
 
 dist_pkgsysconf_DATA =		\
 	milter-manager.conf

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -1,0 +1,2 @@
+SUBDIRS =			\
+	redhat

--- a/data/systemd/redhat/Makefile.am
+++ b/data/systemd/redhat/Makefile.am
@@ -1,9 +1,8 @@
-service = \
-	milter-manager.service
+service = milter-manager.service
 
 if REDHAT_PLATFORM
-initdir = $(sysconfdir)/systemd/redhat
-dist_init_SCRIPTS = $(service)
+initscript_DATA = $(service)
+initscriptdir = $(pkgdatadir)
 else
 EXTRA_DIST = $(service)
 endif

--- a/data/systemd/redhat/Makefile.am
+++ b/data/systemd/redhat/Makefile.am
@@ -1,0 +1,9 @@
+service = \
+	milter-manager.service
+
+if REDHAT_PLATFORM
+initdir = $(sysconfdir)/systemd/redhat
+dist_init_SCRIPTS = $(service)
+else
+EXTRA_DIST = $(service)
+endif

--- a/data/systemd/redhat/milter-manager.service
+++ b/data/systemd/redhat/milter-manager.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=milter-manager server daemon
+After=syslog.target network-online.target
+
+[Service]
+User=milter-manager
+Group=milter-manager
+ExecStart=/usr/sbin/milter-manager $OPTIONS --pid-file "/var/run/milter-manager/milter-manager.pid" --unix-socket-group "mail"
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/data/systemd/redhat/milter-manager.service
+++ b/data/systemd/redhat/milter-manager.service
@@ -3,6 +3,7 @@ Description=milter-manager server daemon
 After=syslog.target network-online.target
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/milter-manager
 User=milter-manager
 Group=milter-manager
 ExecStart=/usr/sbin/milter-manager $OPTIONS --pid-file "/var/run/milter-manager/milter-manager.pid"

--- a/data/systemd/redhat/milter-manager.service
+++ b/data/systemd/redhat/milter-manager.service
@@ -5,7 +5,7 @@ After=syslog.target network-online.target
 [Service]
 User=milter-manager
 Group=milter-manager
-ExecStart=/usr/sbin/milter-manager $OPTIONS --pid-file "/var/run/milter-manager/milter-manager.pid" --unix-socket-group "mail"
+ExecStart=/usr/sbin/milter-manager $OPTIONS --pid-file "/var/run/milter-manager/milter-manager.pid"
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/package/rpm/centos/milter-manager.spec.in
+++ b/package/rpm/centos/milter-manager.spec.in
@@ -2,12 +2,12 @@
 %define ruby_command ruby2.2
 %define ruby_package ruby2.2
 %define ruby_build_requires ruby2.2
-%define use_systemd %(echo 0)
+%define use_systemd 0
 %else
 %define ruby_command ruby
 %define ruby_package ruby
 %define ruby_build_requires ruby ruby-devel
-%define use_systemd %(echo 1)
+%define use_systemd 1
 %endif
 
 %define ruby_version %(%{ruby_command} -e "print RUBY_VERSION.tr('.', '')")

--- a/package/rpm/centos/milter-manager.spec.in
+++ b/package/rpm/centos/milter-manager.spec.in
@@ -29,7 +29,7 @@ BuildRequires: gcc
 BuildRequires: make
 BuildRequires: glib2-devel
 BuildRequires: %{ruby_build_requires}
-%if use_systemd
+%if %use_systemd
 BuildRequires: systemd-units
 %endif
 Requires: %{name}-libs = %{version}-%{release}
@@ -244,7 +244,7 @@ make %{?_smp_mflags}
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
-%if use_systemd
+%if %use_systemd
 install -D -m 644 %{buildroot}/%{_sysconfdir}/systemd/redhat/milter-manager.service %{buildroot}/%{_unitdir}/milter-manager.service
 %endif
 find $RPM_BUILD_ROOT%{_libdir}/ -name \*.la | xargs rm
@@ -349,7 +349,7 @@ fi
 %{_initrddir}/milter-manager
 %{_sysconfdir}/rc.d/init.d/
 %{_sysconfdir}/systemd/redhat/
-%if use_systemd
+%if %use_systemd
 %{_unitdir}/milter-manager.service
 %endif
 %config(noreplace) %{_sysconfdir}/sysconfig/milter-manager

--- a/package/rpm/centos/milter-manager.spec.in
+++ b/package/rpm/centos/milter-manager.spec.in
@@ -2,10 +2,12 @@
 %define ruby_command ruby2.2
 %define ruby_package ruby2.2
 %define ruby_build_requires ruby2.2
+%define use_systemd %(echo 0)
 %else
 %define ruby_command ruby
 %define ruby_package ruby
 %define ruby_build_requires ruby ruby-devel
+%define use_systemd %(echo 1)
 %endif
 
 %define ruby_version %(%{ruby_command} -e "print RUBY_VERSION.tr('.', '')")
@@ -27,6 +29,9 @@ BuildRequires: gcc
 BuildRequires: make
 BuildRequires: glib2-devel
 BuildRequires: %{ruby_build_requires}
+%if use_systemd
+BuildRequires: systemd-units
+%endif
 Requires: %{name}-libs = %{version}-%{release}
 Requires: ruby-milter-client = %{version}-%{release}
 Requires: ruby-milter-server = %{version}-%{release}
@@ -239,6 +244,9 @@ make %{?_smp_mflags}
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
+%if use_systemd
+install -D -m 644 %{buildroot}/%{_sysconfdir}/systemd/redhat/milter-manager.service %{buildroot}/%{_unitdir}/milter-manager.service
+%endif
 find $RPM_BUILD_ROOT%{_libdir}/ -name \*.la | xargs rm
 
 chmod 600 %{buildroot}%{_sysconfdir}/cron.d/milter-manager-log
@@ -340,6 +348,10 @@ fi
 %{_mandir}/ja/man1/milter-manager.*
 %{_initrddir}/milter-manager
 %{_sysconfdir}/rc.d/init.d/
+%{_sysconfdir}/systemd/redhat/
+%if use_systemd
+%{_unitdir}/milter-manager.service
+%endif
 %config(noreplace) %{_sysconfdir}/sysconfig/milter-manager
 %config(noreplace) %{_sysconfdir}/milter-manager/milter-manager.conf
 %config %{_sysconfdir}/milter-manager/defaults/

--- a/package/rpm/centos/milter-manager.spec.in
+++ b/package/rpm/centos/milter-manager.spec.in
@@ -245,7 +245,7 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
 %if %use_systemd
-install -D -m 644 %{buildroot}/%{_sysconfdir}/systemd/redhat/milter-manager.service %{buildroot}/%{_unitdir}/milter-manager.service
+install -D -m 644 %{buildroot}/%{_datadir}/milter-manager/milter-manager.service %{buildroot}/%{_unitdir}/milter-manager.service
 %endif
 find $RPM_BUILD_ROOT%{_libdir}/ -name \*.la | xargs rm
 
@@ -348,7 +348,7 @@ fi
 %{_mandir}/ja/man1/milter-manager.*
 %{_initrddir}/milter-manager
 %{_sysconfdir}/rc.d/init.d/
-%{_sysconfdir}/systemd/redhat/
+%{_datadir}/milter-manager/milter-manager.service
 %if %use_systemd
 %{_unitdir}/milter-manager.service
 %endif


### PR DESCRIPTION
I've tried to add systemd unit file for CentOS7.

This unit file works like this:

```log
$ sudo systemctl start milter-manager
$ sudo systemctl status milter-manager -l
milter-manager.service - milter-manager server daemon
   Loaded: loaded (/usr/lib/systemd/system/milter-manager.service; disabled)
   Active: active (running) since 火 2015-11-24 06:54:12 GMT; 6s ago
 Main PID: 4254 (milter-manager)
   CGroup: /system.slice/milter-manager.service
           ├─4254 /usr/sbin/milter-manager --pid-file /var/run/milter-manager/milter-manager.pid
           └─4258 /usr/sbin/milter-manager --pid-file /var/run/milter-manager/milter-manager.pid

11月 24 06:54:12 localhost.localdomain systemd[1]: Started milter-manager server daemon.
```

This implementation is early stage. So, perhaps, it's not sophisticated about packaging, systemd unit file, and autogen.sh && ./configure processes.