### PR TITLE
Error "in `const_get': wrong constant name TEMPORARY-FAILURE" occurs

### DIFF
--- a/binding/ruby/lib/milter/client/session-context.rb
+++ b/binding/ruby/lib/milter/client/session-context.rb
@@ -25,7 +25,7 @@ module Milter
     def status=(value)
       case value
       when String, Symbol
-        unless Milter::Status.const_defined?(value.to_s.upcase)
+        unless Milter::Status.const_defined?(value.to_s.upcase.gsub(/-/,'_'))
           raise ArgumentError, "unknown status: <#{value.inspect}>"
         end
       when Milter::Status, nil
@@ -41,7 +41,7 @@ module Milter
     def status
       status = @status || Milter::Status::DEFAULT
       if status.is_a?(String) or status.is_a?(Symbol)
-        status = Milter::Status.const_get(status.to_s.upcase)
+        status = Milter::Status.const_get(status.to_s.upcase.gsub(/-/,'_'))
       end
       status
     end


### PR DESCRIPTION
'falback-status' option is not working when 'temporary-failure'.
milter program abend in the confirmation of TEMPORARY-FAILURE(Milter::STATUS)
i think 'TEMPORARY_FAILURE' is correct. please fix.

$ ruby -r milter -e 'p Milter::VERSION'
[2, 0, 7]