### PR TITLE
CentOS 7: installation failed due to repodata/repomd.xml HTTP Error 404

### DIFF
--- a/package/yum/build-release-rpm.sh
+++ b/package/yum/build-release-rpm.sh
@@ -86,19 +86,19 @@ EOR
     run cp -p $rpm_base_dir/RPMS/noarch/${PACKAGE}-release-* $top_dir
     run cp -p $rpm_base_dir/SRPMS/${PACKAGE}-release-* $top_dir
 
-    run mkdir -p $top_dir/5/stable/i386/Packages/
-    run mkdir -p $top_dir/5/stable/x86_64/Packages/
-    run mkdir -p $top_dir/5/stable/source/SRPMS/
-    run cp -p $rpm_base_dir/RPMS/noarch/${PACKAGE}-release-* $top_dir/5/stable/i386/Packages/
-    run cp -p $rpm_base_dir/RPMS/noarch/${PACKAGE}-release-* $top_dir/5/stable/x86_64/Packages/
-    run cp -p $rpm_base_dir/SRPMS/${PACKAGE}-release-* $top_dir/5/stable/source/SRPMS/
-
     run mkdir -p $top_dir/6/stable/i386/Packages/
     run mkdir -p $top_dir/6/stable/x86_64/Packages/
     run mkdir -p $top_dir/6/stable/source/SRPMS/
     run cp -p $rpm_base_dir/RPMS/noarch/${PACKAGE}-release-* $top_dir/6/stable/i386/Packages/
     run cp -p $rpm_base_dir/RPMS/noarch/${PACKAGE}-release-* $top_dir/6/stable/x86_64/Packages/
     run cp -p $rpm_base_dir/SRPMS/${PACKAGE}-release-* $top_dir/6/stable/source/SRPMS/
+
+    run mkdir -p $top_dir/7/stable/i386/Packages/
+    run mkdir -p $top_dir/7/stable/x86_64/Packages/
+    run mkdir -p $top_dir/7/stable/source/SRPMS/
+    run cp -p $rpm_base_dir/RPMS/noarch/${PACKAGE}-release-* $top_dir/7/stable/i386/Packages/
+    run cp -p $rpm_base_dir/RPMS/noarch/${PACKAGE}-release-* $top_dir/7/stable/x86_64/Packages/
+    run cp -p $rpm_base_dir/SRPMS/${PACKAGE}-release-* $top_dir/7/stable/source/SRPMS/
 
     run cp -p ${script_base_dir}/RPM-GPG-KEY-${PACKAGE} $top_dir
 done


### PR DESCRIPTION
```
Loaded plugins: fastestmirror
http://downloads.sourceforge.net/project/milter-manager/centos/7/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
Trying other mirror.
To address this issue please refer to the below knowledge base article 

https://access.redhat.com/articles/1320623

If above article doesn't help to resolve this issue please create a bug on https://bugs.centos.org/



 One of the configured repositories failed (milter manager for CentOS 7 - x86_64),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Disable the repository, so yum won't use it by default. Yum will then
        just ignore the repository until you permanently enable it again or use
        --enablerepo for temporary usage:

            yum-config-manager --disable milter-manager

     4. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=milter-manager.skip_if_unavailable=true

failure: repodata/repomd.xml from milter-manager: [Errno 256] No more mirrors to try.
http://downloads.sourceforge.net/project/milter-manager/centos/7/stable/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
```

Workaround: remove `$basearch/` from the following line in `/etc/yum.repos.d/milter-manager.repo`

```
baseurl=http://downloads.sourceforge.net/project/milter-manager/centos/$releasever/stable/$basearch/
```

ビルドスクリプトを眺めたところ、この PR の変更で [createrepo の巡回リスト](https://github.com/milter-manager/milter-manager/blob/master/package/yum/update-repository.sh#L24-L39)に加わるのではないかという印象を持ちました。
実際にビルドしての確認はできていないのですが、添えておきます。