### PR TITLE
milter-test-server: add disable timeout option

### DIFF
--- a/milter/server/milter-server-context.c
+++ b/milter/server/milter-server-context.c
@@ -3600,6 +3600,19 @@ milter_server_context_set_end_of_message_timeout (MilterServerContext *context,
     MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->end_of_message_timeout = timeout;
 }
 
+void
+milter_server_context_set_all_timeout (MilterServerContext *context,
+                                       gdouble timeout)
+{
+    if(timeout != 0xFFFFFFFF)
+    {
+        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->connection_timeout = timeout;
+        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->writing_timeout = timeout;
+        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->reading_timeout = timeout;
+        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->end_of_message_timeout = timeout;
+    }else{}
+}
+
 gboolean
 milter_server_context_get_skip_body (MilterServerContext *context)
 {

--- a/milter/server/milter-server-context.c
+++ b/milter/server/milter-server-context.c
@@ -3601,7 +3601,7 @@ milter_server_context_set_end_of_message_timeout (MilterServerContext *context,
 }
 
 void
-milter_server_context_set_all_timeout (MilterServerContext *context,
+milter_server_context_set_all_timeouts (MilterServerContext *context,
                                        gdouble timeout)
 {
     MilterServerContextPrivate *priv;

--- a/milter/server/milter-server-context.c
+++ b/milter/server/milter-server-context.c
@@ -3604,13 +3604,12 @@ void
 milter_server_context_set_all_timeout (MilterServerContext *context,
                                        gdouble timeout)
 {
-    if(timeout != 0xFFFFFFFF)
-    {
+    if (timeout > MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT ) {
         MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->connection_timeout = timeout;
         MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->writing_timeout = timeout;
         MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->reading_timeout = timeout;
         MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->end_of_message_timeout = timeout;
-    }else{}
+    }
 }
 
 gboolean

--- a/milter/server/milter-server-context.c
+++ b/milter/server/milter-server-context.c
@@ -3604,11 +3604,15 @@ void
 milter_server_context_set_all_timeout (MilterServerContext *context,
                                        gdouble timeout)
 {
+    MilterServerContextPrivate *priv;
+
+    priv = MILTER_SERVER_CONTEXT_GET_PRIVATE(context);
+
     if (timeout > MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT ) {
-        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->connection_timeout = timeout;
-        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->writing_timeout = timeout;
-        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->reading_timeout = timeout;
-        MILTER_SERVER_CONTEXT_GET_PRIVATE(context)->end_of_message_timeout = timeout;
+        priv->connection_timeout = timeout;
+        priv->writing_timeout = timeout;
+        priv->reading_timeout = timeout;
+        priv->end_of_message_timeout = timeout;
     }
 }
 

--- a/milter/server/milter-server-context.c
+++ b/milter/server/milter-server-context.c
@@ -3608,12 +3608,10 @@ milter_server_context_set_all_timeouts (MilterServerContext *context,
 
     priv = MILTER_SERVER_CONTEXT_GET_PRIVATE(context);
 
-    if (timeout > MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT ) {
-        priv->connection_timeout = timeout;
-        priv->writing_timeout = timeout;
-        priv->reading_timeout = timeout;
-        priv->end_of_message_timeout = timeout;
-    }
+    priv->connection_timeout = timeout;
+    priv->writing_timeout = timeout;
+    priv->reading_timeout = timeout;
+    priv->end_of_message_timeout = timeout;
 }
 
 gboolean

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -289,7 +289,7 @@ void                 milter_server_context_set_end_of_message_timeout
                                                        (MilterServerContext *context,
                                                         gdouble timeout);
 /**
- * milter_server_context_set_all_timeout:
+ * milter_server_context_set_all_timeouts:
  * @context: a %MilterServerContext.
  * @timeout: the timeout in seconds.
  *           (default is
@@ -303,7 +303,7 @@ void                 milter_server_context_set_end_of_message_timeout
  *  3.milter_server_context_set_reading_timeout
  *  4.milter_server_context_set_end_of_message_timeout
  */
-void                 milter_server_context_set_all_timeout
+void                 milter_server_context_set_all_timeouts
                                                        (MilterServerContext *context,
                                                         gdouble timeout);
 /**

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -284,12 +284,12 @@ void                 milter_server_context_set_end_of_message_timeout
  * milter_server_context_set_all_timeouts:
  * @context: a %MilterServerContext.
  * @timeout: the timeout in seconds.
- *           (default is
- *           %MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT)
  *
- * Sets the timeout in seconds on connection timeout, writing timeout, reading timeout and end-of-timeout.
+ * Sets the timeout in seconds on connection timeout, writing timeout,
+ * reading timeout and end-of-timeout all at once.
  *
- * See the comment of these function about each timeout.
+ * See the comments of the fllowing functions about each timeout:
+ *
  *  1.milter_server_context_set_connection_timeout
  *  2.milter_server_context_set_writing_timeout
  *  3.milter_server_context_set_reading_timeout

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -291,17 +291,17 @@ void                 milter_server_context_set_end_of_message_timeout
 /**
  * milter_server_context_set_all_timeout:
  * @context: a %MilterServerContext.
- * @timeout: the timeout by seconds.
+ * @timeout: the timeout in seconds.
  *           (default is
  *           %MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT)
  *
- * Sets the timeout by seconds on connection timeout, writing timeout, reading timeout and end-of-timeout.
+ * Sets the timeout in seconds on connection timeout, writing timeout, reading timeout and end-of-timeout.
  *
- * #MilterServerContext::timeout signal is emitted for four reasons.
- * 1. Doesn't receive response for end-of-message from client socket in @timeout seconds.
- * 2. Doesn't connects to client in @timeout seconds.
- * 3. Doesn't write to client socket in @timeout seconds.
- * 4. Doesn't receive response from client socket in @timeout seconds.
+ * See the comment of these function about each timeout.
+ *  1.milter_server_context_set_connection_timeout
+ *  2.milter_server_context_set_writing_timeout
+ *  3.milter_server_context_set_reading_timeout
+ *  4.milter_server_context_set_end_of_message_timeout
  */
 void                 milter_server_context_set_all_timeout
                                                        (MilterServerContext *context,

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -82,10 +82,7 @@ G_BEGIN_DECLS
 /**
  * MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT:
  *
- * The default all timeout option value.
- * if this value is a negative number, "all-timeout" option has been invalided.
- * if this value is a natural number(include 0), "all-timeout" option has been valid
- * and this value is timeout by seconds.
+ * The default value for all timeout option.
 **/
 #define MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT             -1
 

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -84,8 +84,8 @@ G_BEGIN_DECLS
  *
  * The default all timeout option value.
  * if this value is a negative number, "all-timeout" option has been invalided.
- * if this value is a natural number(include 0), "all-timeout" option has been valid 
- * and this value is timeout by seconds.  
+ * if this value is a natural number(include 0), "all-timeout" option has been valid
+ * and this value is timeout by seconds.
 **/
 #define MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT             -1
 
@@ -308,7 +308,7 @@ void                 milter_server_context_set_end_of_message_timeout
  */
 void                 milter_server_context_set_all_timeout
                                                        (MilterServerContext *context,
-                                                        gdouble timeout);                                                       
+                                                        gdouble timeout);
 /**
  * milter_server_context_set_connection_spec:
  * @context: a %MilterServerContext.

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -79,7 +79,17 @@ G_BEGIN_DECLS
  **/
 #define MILTER_SERVER_CONTEXT_DEFAULT_END_OF_MESSAGE_TIMEOUT 300
 
-#define MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT     0xFFFFFFFF
+/**
+ * MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT:
+ *
+ * The default all timeout option value.
+ * if this value is a negative number, "all-timeout" option has been invalided.
+ * if this value is a natural number(include 0), "all-timeout" option has been valid 
+ * and this value is timeout by seconds.  
+**/
+#define MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT             -1
+
+
 /**
  * MilterServerContextError:
  * @MILTER_SERVER_CONTEXT_ERROR_CONNECTION_FAILURE: Indicates a
@@ -281,7 +291,21 @@ void                 milter_server_context_set_reading_timeout
 void                 milter_server_context_set_end_of_message_timeout
                                                        (MilterServerContext *context,
                                                         gdouble timeout);
-
+/**
+ * milter_server_context_set_all_timeout:
+ * @context: a %MilterServerContext.
+ * @timeout: the timeout by seconds.
+ *           (default is
+ *           %MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT)
+ *
+ * Sets the timeout by seconds on connection timeout, writing timeout, reading timeout and end-of-timeout.
+ *
+ * #MilterServerContext::timeout signal is emitted for four reasons.
+ * 1. Doesn't receive response for end-of-message from client socket in @timeout seconds.
+ * 2. Doesn't connects to client in @timeout seconds.
+ * 3. Doesn't write to client socket in @timeout seconds.
+ * 4. Doesn't receive response from client socket in @timeout seconds.
+ */
 void                 milter_server_context_set_all_timeout
                                                        (MilterServerContext *context,
                                                         gdouble timeout);                                                       

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -79,6 +79,7 @@ G_BEGIN_DECLS
  **/
 #define MILTER_SERVER_CONTEXT_DEFAULT_END_OF_MESSAGE_TIMEOUT 300
 
+#define MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT     0xFFFFFFFF
 /**
  * MilterServerContextError:
  * @MILTER_SERVER_CONTEXT_ERROR_CONNECTION_FAILURE: Indicates a
@@ -281,6 +282,9 @@ void                 milter_server_context_set_end_of_message_timeout
                                                        (MilterServerContext *context,
                                                         gdouble timeout);
 
+void                 milter_server_context_set_all_timeout
+                                                       (MilterServerContext *context,
+                                                        gdouble timeout);                                                       
 /**
  * milter_server_context_set_connection_spec:
  * @context: a %MilterServerContext.

--- a/milter/server/milter-server-context.h
+++ b/milter/server/milter-server-context.h
@@ -80,14 +80,6 @@ G_BEGIN_DECLS
 #define MILTER_SERVER_CONTEXT_DEFAULT_END_OF_MESSAGE_TIMEOUT 300
 
 /**
- * MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT:
- *
- * The default value for all timeout option.
-**/
-#define MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT             -1
-
-
-/**
  * MilterServerContextError:
  * @MILTER_SERVER_CONTEXT_ERROR_CONNECTION_FAILURE: Indicates a
  * connection failure.

--- a/tool/milter-test-server.c
+++ b/tool/milter-test-server.c
@@ -1606,7 +1606,8 @@ static const GOptionEntry option_entries[] =
     {"end-of-message-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &writing_timeout,
      N_("Timeout after SECONDS seconds on end-of-message command."), "SECONDS"},
     {"all-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &all_timeout,
-     N_("Timeout after SECONDS seconds on all(connection, reading, writing, end-of-message) timepout command."), "SECONDS"},     
+     N_("Set all timeout (connection-timeout, reading-timeout, writing-timeout, end-of-message-timeout)" 
+         "value on SECONDS seconds."), "SECONDS"},     
     {"threads", 't', 0, G_OPTION_ARG_INT, &n_threads,
      N_("Create N threads."), "N"},
     {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,

--- a/tool/milter-test-server.c
+++ b/tool/milter-test-server.c
@@ -1606,8 +1606,8 @@ static const GOptionEntry option_entries[] =
     {"end-of-message-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &writing_timeout,
      N_("Timeout after SECONDS seconds on end-of-message command."), "SECONDS"},
     {"all-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &all_timeout,
-     N_("Set all timeout (connection-timeout, reading-timeout, writing-timeout, end-of-message-timeout)"
-         "value on SECONDS seconds."), "SECONDS"},
+     N_("Set all timeout (connection-timeout, reading-timeout, writing-timeout, end-of-message-timeout"),
+     "SECONDS"},
     {"threads", 't', 0, G_OPTION_ARG_INT, &n_threads,
      N_("Create N threads."), "N"},
     {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,

--- a/tool/milter-test-server.c
+++ b/tool/milter-test-server.c
@@ -1606,8 +1606,8 @@ static const GOptionEntry option_entries[] =
     {"end-of-message-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &writing_timeout,
      N_("Timeout after SECONDS seconds on end-of-message command."), "SECONDS"},
     {"all-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &all_timeout,
-     N_("Set all timeout (connection-timeout, reading-timeout, writing-timeout, end-of-message-timeout)" 
-         "value on SECONDS seconds."), "SECONDS"},     
+     N_("Set all timeout (connection-timeout, reading-timeout, writing-timeout, end-of-message-timeout)"
+         "value on SECONDS seconds."), "SECONDS"},
     {"threads", 't', 0, G_OPTION_ARG_INT, &n_threads,
      N_("Create N threads."), "N"},
     {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,

--- a/tool/milter-test-server.c
+++ b/tool/milter-test-server.c
@@ -2257,7 +2257,7 @@ setup_context (MilterServerContext *context, ProcessData *process_data)
     milter_server_context_set_writing_timeout(context, writing_timeout);
     milter_server_context_set_end_of_message_timeout(context,
                                                      end_of_message_timeout);
-    milter_server_context_set_all_timeout(context, all_timeout);
+    milter_server_context_set_all_timeouts(context, all_timeout);
 
     g_signal_connect(context, "ready", G_CALLBACK(cb_ready), process_data);
     g_signal_connect(context, "error", G_CALLBACK(cb_connection_error), process_data);

--- a/tool/milter-test-server.c
+++ b/tool/milter-test-server.c
@@ -73,6 +73,7 @@ static gdouble connection_timeout = MILTER_SERVER_CONTEXT_DEFAULT_CONNECTION_TIM
 static gdouble writing_timeout = MILTER_SERVER_CONTEXT_DEFAULT_WRITING_TIMEOUT;
 static gdouble reading_timeout = MILTER_SERVER_CONTEXT_DEFAULT_READING_TIMEOUT;
 static gdouble end_of_message_timeout = MILTER_SERVER_CONTEXT_DEFAULT_END_OF_MESSAGE_TIMEOUT;
+static gdouble all_timeout = MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT;
 
 #define MILTER_TEST_SERVER_ERROR                                \
     (g_quark_from_static_string("milter-test-server-error-quark"))
@@ -1604,6 +1605,8 @@ static const GOptionEntry option_entries[] =
      N_("Timeout after SECONDS seconds on writing a command."), "SECONDS"},
     {"end-of-message-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &writing_timeout,
      N_("Timeout after SECONDS seconds on end-of-message command."), "SECONDS"},
+    {"all-timeout", 0, 0, G_OPTION_ARG_DOUBLE, &all_timeout,
+     N_("Timeout after SECONDS seconds on all(connection, reading, writing, end-of-message) timepout command."), "SECONDS"},     
     {"threads", 't', 0, G_OPTION_ARG_INT, &n_threads,
      N_("Create N threads."), "N"},
     {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,
@@ -2253,6 +2256,7 @@ setup_context (MilterServerContext *context, ProcessData *process_data)
     milter_server_context_set_writing_timeout(context, writing_timeout);
     milter_server_context_set_end_of_message_timeout(context,
                                                      end_of_message_timeout);
+    milter_server_context_set_all_timeout(context, all_timeout);
 
     g_signal_connect(context, "ready", G_CALLBACK(cb_ready), process_data);
     g_signal_connect(context, "error", G_CALLBACK(cb_connection_error), process_data);

--- a/tool/milter-test-server.c
+++ b/tool/milter-test-server.c
@@ -2257,7 +2257,11 @@ setup_context (MilterServerContext *context, ProcessData *process_data)
     milter_server_context_set_writing_timeout(context, writing_timeout);
     milter_server_context_set_end_of_message_timeout(context,
                                                      end_of_message_timeout);
-    milter_server_context_set_all_timeouts(context, all_timeout);
+
+    if (all_timeout >= 0.0) {
+        milter_server_context_set_all_timeouts(context, all_timeout);
+    }
+
 
     g_signal_connect(context, "ready", G_CALLBACK(cb_ready), process_data);
     g_signal_connect(context, "error", G_CALLBACK(cb_connection_error), process_data);

--- a/tool/milter-test-server.c
+++ b/tool/milter-test-server.c
@@ -43,6 +43,7 @@
 #include <milter/core/milter-glib-compatible.h>
 
 #define DEFAULT_NEGOTIATE_VERSION 6
+#define MILTER_TEST_SERVER_ALL_TIMEOUT_UNSPECIFIED -1.0
 
 static gboolean verbose = FALSE;
 static gboolean output_message = FALSE;
@@ -73,7 +74,7 @@ static gdouble connection_timeout = MILTER_SERVER_CONTEXT_DEFAULT_CONNECTION_TIM
 static gdouble writing_timeout = MILTER_SERVER_CONTEXT_DEFAULT_WRITING_TIMEOUT;
 static gdouble reading_timeout = MILTER_SERVER_CONTEXT_DEFAULT_READING_TIMEOUT;
 static gdouble end_of_message_timeout = MILTER_SERVER_CONTEXT_DEFAULT_END_OF_MESSAGE_TIMEOUT;
-static gdouble all_timeout = MILTER_SERVER_CONTEXT_DEFAULT_ALL_TIMEOUT;
+static gdouble all_timeout = MILTER_TEST_SERVER_ALL_TIMEOUT_UNSPECIFIED;
 
 #define MILTER_TEST_SERVER_ERROR                                \
     (g_quark_from_static_string("milter-test-server-error-quark"))


### PR DESCRIPTION
## **修正内容**

1. 以下の4つのタイムアウト値を一括で変更するオプション(--all-timeout)を追加しました。
 
 - connection\-timeout
 - reading\-timeout
 - writing\-timeout
 - end\-of\-message\-timeout

2. milter-test-server --helpにall-timeoutオプションの説明と使い方を追加しました。

### **備考**

all-timeoutオプションに0以上の値を設定することで本機能は有効になります。
all-timeoutオプションを指定しない または、負の値を設定した場合は、本機能は無効になります。