### PR TITLE
add DNSBL applicable condition

### DIFF
--- a/data/applicable-conditions/dnsbl.conf
+++ b/data/applicable-conditions/dnsbl.conf
@@ -1,0 +1,80 @@
+# -*- ruby -*-
+
+require 'resolv'
+
+dnsbl = Object.new
+dnsbl.instance_eval do
+  @blackholes = []
+end
+
+class << dnsbl
+  TIMEOUT = 5
+
+  def add_blackhole(service_domain, expected_answer = nil)
+    if expected_answer
+      @blackholes.push([service_domain, IPAddr.new(expected_answer)])
+    else
+      @blackholes.push([service_domain, nil])
+    end
+  end
+
+  def black?(address)
+    return false if !address.ipv4?
+    listed_address?(@blackholes, address)
+  end
+
+  private
+  def listed_address?(blackholes, address)
+    rev_address = address.address.split(".").reverse.join(".")
+
+    answers = [nil] * blackholes.size
+
+    threads = []
+    blackholes.each_with_index do |blackhole, idx|
+      service_domain, expected_answer = *blackhole
+      query_domain = rev_address + "." + service_domain
+
+      threads << Thread.new do
+        thread_idx = idx
+        resolver = Resolv::DNS.new(:nameserver => ['8.8.8.8', '8.8.4.4'])
+        resolver.timeouts = TIMEOUT
+
+        begin
+          answer = resolver.getaddress(query_domain)
+          if expected_answer
+            answers[thread_idx] = expected_answer.include?(answer.to_s)
+          else
+            answers[thread_idx] = true
+          end
+        rescue Exception => err # or Resolv::ResolvError
+          answers[thread_idx] = false
+        end
+      end
+    end
+    threads.each(&:join)
+
+    answers.any?
+  end
+end
+
+singleton_class = class << self; self; end
+singleton_class.send(:define_method, :dnsbl) do
+  dnsbl
+end
+
+dnsbl.add_blackhole("zen.spamhaus.org", "127.0.0.10/31")
+dnsbl.add_blackhole("dnsbl.sorbs.net", "127.0.0.10")
+dnsbl.add_blackhole("bl.spamcop.net", "127.0.0.2")
+dnsbl.add_blackhole("b.barracudacentral.org", "127.0.0.2")
+
+define_applicable_condition("DNSBL") do |condition|
+  condition.description = "DNS-based Blackhole List"
+
+  condition.define_connect_stopper do |context, host, address|
+    if dnsbl.black?(address)
+      false
+    else
+      true
+    end
+  end
+end


### PR DESCRIPTION
Implemented a DNSBL based applicable condition.

milter-manager uses S25R as an applicable condition of milter-greylist by default. S25R is mostly sound but not complete, and actually many spammers evade application of milter-greylist.
DNSBL could be an another choice for an applicable condition of milter-greylist.

Current implementation uses SPAMHAUS, SORBS, SPAMCOP, BARRACUDA as default black hole lists.
DNS resolvers are multithreaded for each black hole list, so adding more black hole lists does not increase processing latency.
