### PR TITLE
Fix "Authentication" typos in configuration document

### DIFF
--- a/doc/configuration.rd
+++ b/doc/configuration.rd
@@ -1480,7 +1480,7 @@ inner to outer mail, is Bcc-ed to be audited:
 Example:
 
   define_milter("milter-bcc") do |milter|
-    milter.add_applicable_condition("Authentication")
+    milter.add_applicable_condition("Authenticated")
   end
 
 === [unauthentication] Unauthentication
@@ -1496,7 +1496,7 @@ is applied spam-check to avoid false detection.
 Example:
 
   define_milter("spamass-milter") do |milter|
-    milter.add_applicable_condition("Unauthentication")
+    milter.add_applicable_condition("Unauthenticated")
   end
 
 === Sendmail Compatible

--- a/doc/configuration.rd.ja
+++ b/doc/configuration.rd.ja
@@ -1453,7 +1453,7 @@ main.cf:
 使用例:
 
   define_milter("milter-bcc") do |milter|
-    milter.add_applicable_condition("Authentication")
+    milter.add_applicable_condition("Authenticated")
   end
 
 === [unauthentication] Unauthentication
@@ -1468,7 +1468,7 @@ SMTP Authで認証されていないSMTPクライアントにのみ子milterを�
 使用例:
 
   define_milter("spamass-milter") do |milter|
-    milter.add_applicable_condition("Unauthentication")
+    milter.add_applicable_condition("Unauthenticated")
   end
 
 === Sendmail Compatible


### PR DESCRIPTION
ドキュメントの内容が以前の「Authentication」になっていたので「Authenticated」に修正