### PR TITLE
milter core: ensure to sort hash table keys

### DIFF
--- a/milter/core/milter-utils.c
+++ b/milter/core/milter-utils.c
@@ -432,6 +432,11 @@ inspect_hash_string_string_element (gpointer _key, gpointer _value,
     g_string_append(inspected, ", ");
 }
 
+static gint compare_hash_key(gconstpointer a, gconstpointer b)
+{
+  return g_strcmp0((gchar*)a, (gchar*)b);
+}
+
 gchar *
 milter_utils_inspect_hash_string_string (GHashTable *hash)
 {
@@ -439,9 +444,14 @@ milter_utils_inspect_hash_string_string (GHashTable *hash)
 
     inspected = g_string_new("{");
     if (g_hash_table_size(hash) > 0) {
-        g_hash_table_foreach(hash,
-                             inspect_hash_string_string_element,
-                             inspected);
+        GList *key_list = g_hash_table_get_keys(hash);
+        key_list = g_list_sort(key_list, compare_hash_key);
+        const GList *node;
+        for (node = key_list; node; node = g_list_next(node)) {
+            gpointer value = g_hash_table_lookup(hash, node->data);
+            inspect_hash_string_string_element(node->data, value, inspected);
+        }
+        g_list_free(key_list);
         g_string_truncate(inspected, inspected->len - strlen(", "));
     }
     g_string_append(inspected, "}");


### PR DESCRIPTION
This commit fixes the following random error:
(It was caused because GHashTable doesn't gurantee the order of inserted
keys)

  Failure: test_inspect_hash_string_string
  <"{" "\"name1\" => \"value1\", " "\"name2\" => \"value2\"" "}" ==
inspected>
   expected: <"{\"name1\" => \"value1\", \"name2\" => \"value2\"}">
   actual: <"{\"name2\" => \"value2\", \"name1\" => \"value1\"}">