### PR TITLE
doc available-milters: update milter-regex URL

### DIFF
--- a/doc/available-milters.rd
+++ b/doc/available-milters.rd
@@ -55,6 +55,6 @@ please report it to ((<mailing
 list|URL:http://lists.osdn.me/mailman/listinfo/milter-manager-users-en>)).
 
   * ((<AntiVir MailGate|URL:http://www.avira.com/en/products/avira_antivir_mailgate.html>))
-  * ((<milter-regex|URL:http://www.benzedrine.cx/milter-regex.html>))
+  * ((<milter-regex|URL:http://www.benzedrine.ch/milter-regex.html>))
   * ((<MIMEDefang|URL:http://www.mimedefang.org/>))
   * ...

--- a/doc/available-milters.rd.ja
+++ b/doc/available-milters.rd.ja
@@ -51,6 +51,6 @@ milter managerと一緒に利用できたことが報告されているmilterを
 
 動作を確認した場合は教えてもらえると助かります。
 
-  * ((<milter-regex|URL:http://www.benzedrine.cx/milter-regex.html>))
+  * ((<milter-regex|URL:http://www.benzedrine.ch/milter-regex.html>))
   * ((<MIMEDefang|URL:http://www.mimedefang.org/>))
   * ...


### PR DESCRIPTION
moved 5 years ago and old URL is owned by someone else now.