### PR TITLE
Fix confusion between GQuark and GType

### DIFF
--- a/binding/ruby/ext/core/rb-milter-decoder.c
+++ b/binding/ruby/ext/core/rb-milter-decoder.c
@@ -81,11 +81,11 @@ Init_milter_decoder (void)
                                          "ReplyDecoder", rb_mMilter);
     rb_cMilterCommandDecoder = G_DEF_CLASS(MILTER_TYPE_COMMAND_DECODER,
                                            "CommandDecoder", rb_mMilter);
-    G_DEF_ERROR2(MILTER_TYPE_DECODER_ERROR, "DecoderError",
+    G_DEF_ERROR2(MILTER_DECODER_ERROR, "DecoderError",
                  rb_mMilter, rb_eMilterError);
-    G_DEF_ERROR2(MILTER_TYPE_COMMAND_DECODER_ERROR, "CommandDecoderError",
+    G_DEF_ERROR2(MILTER_COMMAND_DECODER_ERROR, "CommandDecoderError",
                  rb_mMilter, rb_eMilterError);
-    G_DEF_ERROR2(MILTER_TYPE_REPLY_DECODER_ERROR, "ReplyDecoderError",
+    G_DEF_ERROR2(MILTER_REPLY_DECODER_ERROR, "ReplyDecoderError",
                  rb_mMilter, rb_eMilterError);
 
     rb_define_method(rb_cMilterDecoder, "decode", decode, 1);

--- a/binding/ruby/ext/manager/rb-milter-manager-control-decoder.c
+++ b/binding/ruby/ext/manager/rb-milter-manager-control-decoder.c
@@ -74,10 +74,10 @@ Init_milter_manager_control_decoder (void)
         G_DEF_CLASS(MILTER_TYPE_MANAGER_CONTROL_REPLY_DECODER,
                     "ControlReplyDecoder", rb_mMilterManager);
 
-    G_DEF_ERROR2(MILTER_TYPE_MANAGER_CONTROL_COMMAND_DECODER_ERROR,
+    G_DEF_ERROR2(MILTER_MANAGER_CONTROL_COMMAND_DECODER_ERROR,
                  "ControlCommandDecoderError",
                  rb_mMilterManager, rb_eMilterError);
-    G_DEF_ERROR2(MILTER_TYPE_MANAGER_CONTROL_REPLY_DECODER_ERROR,
+    G_DEF_ERROR2(MILTER_MANAGER_CONTROL_REPLY_DECODER_ERROR,
                  "ControlReplyDecoderError",
                  rb_mMilterManager, rb_eMilterError);
 


### PR DESCRIPTION
G_DEF_ERROR2 requires GQuark, but MILTER_TYPE_* returns GType