### PR TITLE
ci: fix package tests failing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -187,6 +187,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: package-${{ matrix.id }}
+          path: package/${{ matrix.task-namespace }}/repositories
       - name: Run VM
         run: |
           vagrant up ${{ matrix.id }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -181,7 +181,7 @@ jobs:
             task-namespace: yum
             target: almalinux-9
             test-docker-image: almalinux:9
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: .build
       - run: make -j$(nproc)
         working-directory: .build
-      - run: make distcheck
+      - run: make dist
         working-directory: .build
       - run: mv .build/milter-manager-*.tar.gz ./
       - name: Show test/tool/ log

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: .build
       - run: make -j$(nproc)
         working-directory: .build
-      - run: make dist
+      - run: make distcheck
         working-directory: .build
       - run: mv .build/milter-manager-*.tar.gz ./
       - name: Show test/tool/ log

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -149,11 +149,50 @@ jobs:
           files: |
             ${{ matrix.id }}.tar.gz
 
-      # Test
-      - name: Test
+  test:
+    name: Test
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        label:
+          - CentOS 7
+          - Debian GNU/Linux bullseye
+          - AlmaLinux 8
+          - AlmaLinux 9
+        include:
+          - label: CentOS 7
+            id: centos-7
+            task-namespace: yum
+            target: centos-7
+            test-docker-image: centos:7
+          - label: Debian GNU/Linux bullseye
+            id: debian-bullseye
+            task-namespace: apt
+            target: debian-bullseye
+            test-docker-image: debian:bullseye
+          - label: AlmaLinux 8
+            id: almalinux-8
+            task-namespace: yum
+            target: almalinux-8
+            test-docker-image: almalinux:8
+          - label: AlmaLinux 9
+            id: almalinux-9
+            task-namespace: yum
+            target: almalinux-9
+            test-docker-image: almalinux:9
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: package-${{ matrix.id }}
+      - name: Run VM
         run: |
-          docker run \
-            --rm \
-            --volume ${PWD}:/host:ro \
-            ${{ matrix.test-docker-image }} \
-            /host/package/${{ matrix.task-namespace }}/test.sh
+          vagrant up ${{ matrix.id }}
+      - name: Run test
+        run: |
+          vagrant \
+            ssh ${{ matrix.id }} \
+            -- \
+            /vagrant/package/${{ matrix.task-namespace }}/test.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  vms = [
+    {
+      :id => "centos-7",
+      :box => "bento/centos-7",
+    },
+    {
+      :id => "debian-bullseye",
+      :box => "bento/debian-11",
+    },
+    {
+      :id => "almalinux-8",
+      :box => "bento/almalinux-8",
+    },
+    {
+      :id => "almalinux-9",
+      :box => "bento/almalinux-9",
+    },
+    {
+      :id => "ubuntu-bionic",
+      :box => "bento/ubuntu-18.04",
+    },
+    {
+      :id => "ubuntu-focal",
+      :box => "bento/ubuntu-20.04",
+    },
+  ]
+
+  n_cpus = ENV["VM_N_CPUS"] || 2
+  n_cpus = Integer(n_cpus) if n_cpus
+  memory = ENV["VM_MEMORY"] || 1024
+  memory = Integer(memory) if memory
+  vms.each do |vm|
+    id = vm[:id]
+    box = vm[:box] || id
+    config.vm.define(id) do |node|
+      node.vm.box = box
+      node.vm.provider("virtualbox") do |virtual_box|
+        virtual_box.cpus = n_cpus if n_cpus
+        virtual_box.memory = memory if memory
+      end
+    end
+  end
+end

--- a/package/apt/test.sh
+++ b/package/apt/test.sh
@@ -17,8 +17,8 @@
 
 set -exu
 
-apt update
-apt install -V -y curl lsb-release
+sudo apt update
+sudo apt install -V -y curl lsb-release
 
 code_name=$(lsb_release --codename --short)
 architecture=$(dpkg --print-architecture)
@@ -28,7 +28,7 @@ architecture=$(dpkg --print-architecture)
 #   sudo bash
 
 repositories_dir=/host/package/apt/repositories
-apt install -V -y \
+sudo apt install -V -y \
   ${repositories_dir}/debian/pool/${code_name}/*/*/*/*_{${architecture},all}.deb
 
 systemctl status milter-manager

--- a/package/apt/test.sh
+++ b/package/apt/test.sh
@@ -27,7 +27,7 @@ architecture=$(dpkg --print-architecture)
 # curl -s https://packagecloud.io/install/repositories/milter-manager/repos/script.deb.sh | \
 #   sudo bash
 
-repositories_dir=/host/package/apt/repositories
+repositories_dir=/vagrant/package/apt/repositories
 sudo apt install -V -y \
   ${repositories_dir}/debian/pool/${code_name}/*/*/*/*_{${architecture},all}.deb
 

--- a/package/debian/rules
+++ b/package/debian/rules
@@ -32,7 +32,7 @@ override_dh_auto_configure:
 		--with-bundled-ruby-gobject-introspection
 
 override_dh_auto_test:
-	TZ=Asia/Tokyo dh_auto_test
+	: TZ=Asia/Tokyo dh_auto_test
 
 override_dh_install:
 	find $(CURDIR)/debian/tmp/usr/lib/ -name *.la -delete

--- a/package/debian/rules
+++ b/package/debian/rules
@@ -32,7 +32,7 @@ override_dh_auto_configure:
 		--with-bundled-ruby-gobject-introspection
 
 override_dh_auto_test:
-	: TZ=Asia/Tokyo dh_auto_test
+	TZ=Asia/Tokyo dh_auto_test
 
 override_dh_install:
 	find $(CURDIR)/debian/tmp/usr/lib/ -name *.la -delete

--- a/package/yum/test.sh
+++ b/package/yum/test.sh
@@ -31,12 +31,12 @@ case ${os} in
     case ${version} in
       8)
         DNF="dnf --enablerepo=powertools"
-        dnf --enablerepo=powertools -y epel-release
+        dnf --enablerepo=powertools install -y epel-release
         dnf module -y enable ruby:3.0
         ;;
       9)
         DNF="dnf --enablerepo=crb"
-        dnf --enablerepo=crb -y epel-release
+        dnf --enablerepo=crb install -y epel-release
         ;;
     esac
     ;;

--- a/package/yum/test.sh
+++ b/package/yum/test.sh
@@ -20,25 +20,22 @@ set -exu
 os=$(. /etc/os-release && echo $ID)
 version=$(. /etc/os-release && echo $VERSION_ID | grep -oE '^[0-9]+')
 
-case ${os} in
-  centos)
+case ${version} in
+  8)
     DNF=yum
-    sudo yum install -y \
-      centos-release-scl-rh \
-      epel-release
+    sudo ${DNF} install -y \
+         centos-release-scl-rh \
+         epel-release
     ;;
-  almalinux)
-    case ${version} in
-      8)
-        DNF="dnf --enablerepo=powertools"
-        sudo dnf --enablerepo=powertools install -y epel-release
-        sudo dnf module -y enable ruby:3.0
-        ;;
-      9)
-        DNF="dnf --enablerepo=crb"
-        sudo dnf --enablerepo=crb install -y epel-release
-        ;;
-    esac
+  8)
+    DNF="dnf --enablerepo=powertools"
+    sudo ${DNF} install -y epel-release
+    sudo ${DNF} module -y enable ruby:3.0
+    ;;
+  9)
+    DNF="dnf --enablerepo=crb"
+    sudo ${DNF} install -y epel-release
+    DNF="${DNF} --enablerepo=epel-testing"
     ;;
 esac
 
@@ -50,8 +47,9 @@ repositories_dir=/vagrant/package/yum/repositories
 sudo ${DNF} install -y \
   ${repositories_dir}/${os}/${version}/x86_64/Packages/*.rpm
 
+[ ! sudo systemctl status milter-manager ]
 sudo systemctl enable --now milter-manager
-systemctl status milter-manager
+sudo systemctl status milter-manager
 
 # TODO: Run tests or something
 

--- a/package/yum/test.sh
+++ b/package/yum/test.sh
@@ -50,6 +50,7 @@ repositories_dir=/vagrant/package/yum/repositories
 sudo ${DNF} install -y \
   ${repositories_dir}/${os}/${version}/x86_64/Packages/*.rpm
 
+sudo systemctl enable --now milter-manager
 systemctl status milter-manager
 
 # TODO: Run tests or something

--- a/package/yum/test.sh
+++ b/package/yum/test.sh
@@ -47,7 +47,7 @@ repositories_dir=/vagrant/package/yum/repositories
 sudo ${DNF} install -y \
   ${repositories_dir}/${os}/${version}/x86_64/Packages/*.rpm
 
-[ ! sudo systemctl status milter-manager ]
+! sudo systemctl status milter-manager
 sudo systemctl enable --now milter-manager
 sudo systemctl status milter-manager
 

--- a/package/yum/test.sh
+++ b/package/yum/test.sh
@@ -21,7 +21,7 @@ os=$(. /etc/os-release && echo $ID)
 version=$(. /etc/os-release && echo $VERSION_ID | grep -oE '^[0-9]+')
 
 case ${version} in
-  8)
+  7)
     DNF=yum
     sudo ${DNF} install -y \
          centos-release-scl-rh \

--- a/package/yum/test.sh
+++ b/package/yum/test.sh
@@ -23,7 +23,7 @@ version=$(. /etc/os-release && echo $VERSION_ID | grep -oE '^[0-9]+')
 case ${os} in
   centos)
     DNF=yum
-    yum install -y \
+    sudo yum install -y \
       centos-release-scl-rh \
       epel-release
     ;;
@@ -31,12 +31,12 @@ case ${os} in
     case ${version} in
       8)
         DNF="dnf --enablerepo=powertools"
-        dnf --enablerepo=powertools install -y epel-release
-        dnf module -y enable ruby:3.0
+        sudo dnf --enablerepo=powertools install -y epel-release
+        sudo dnf module -y enable ruby:3.0
         ;;
       9)
         DNF="dnf --enablerepo=crb"
-        dnf --enablerepo=crb install -y epel-release
+        sudo dnf --enablerepo=crb install -y epel-release
         ;;
     esac
     ;;
@@ -47,7 +47,7 @@ esac
 #   sudo bash
 
 repositories_dir=/vagrant/package/yum/repositories
-${DNF} install -y \
+sudo ${DNF} install -y \
   ${repositories_dir}/${os}/${version}/x86_64/Packages/*.rpm
 
 systemctl status milter-manager


### PR DESCRIPTION
Package tests are failing now: https://github.com/milter-manager/milter-manager/actions/runs/2701480108

We have to use vagrant to use `systemd` for these tests.
However, we can't use vagrant on Ubuntu in the CI-environment.

So this fix uses macOS for tests.

I refer Mroonga.

* https://github.com/mroonga/mroonga
* https://github.com/mroonga/mroonga/blob/master/.github/workflows/linux.yml
* https://github.com/mroonga/mroonga/blob/master/Vagrantfile

TODO

- [x] Fix `package.yml` to use macOS and vagrant for the tests
- [x] Add `Vagrantfile` to use vagrant
- [x] Fix `test.sh`
- [x] Confirm the tests succeed
