### PR TITLE
Support Meson for milter-client

### DIFF
--- a/meson-config.h.in
+++ b/meson-config.h.in
@@ -16,4 +16,5 @@
  *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define GETTEXT_PACKAGE "@GETTEXT_PACKAGE@"
 #define GLIB_VERSION_MIN_REQUIRED @GLIB_VERSION_MIN_REQUIRED@

--- a/meson.build
+++ b/meson.build
@@ -48,3 +48,4 @@ config = declare_dependency(compile_args: '-DHAVE_CONFIG_H',
                             sources: config_h)
 
 subdir('milter/core')
+subdir('milter/client')

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ pkgconfig = import('pkgconfig')
 pkgconfig_variables = ['girdir=@0@'.format(gir_dir)]
 
 config_h_conf = configuration_data()
+config_h_conf.set('GETTEXT_PACKAGE', 'milter-manager')
 # CentOS 7: GLib 2.50
 # AlmaLinux 8: GLib 2.56
 # AlmaLinux 9: GLib 2.68

--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -56,7 +56,7 @@ pkgconfig.generate(libmilter_client,
                    description: 'milter API',
                    filebase: 'milter-client',
                    name: 'milter client library',
-                   requires: ['gobject-2.0'],
+                   requires: ['milter-core = ' + meson.version()],
                    variables: pkgconfig_variables,
                    version: meson.version())
 

--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -60,7 +60,11 @@ pkgconfig.generate(libmilter_client,
                    variables: pkgconfig_variables,
                    version: meson.version())
 
+dependencies = [
+  declare_dependency(sources: milter_core_gir),
+]
 milter_client_gir = gnome.generate_gir(libmilter_client,
+                                       dependencies: dependencies,
                                        export_packages: 'milter-client',
                                        extra_args: [
                                          '--warn-all',
@@ -69,6 +73,7 @@ milter_client_gir = gnome.generate_gir(libmilter_client,
                                        header: 'milter/client.h',
                                        identifier_prefix: 'Milter',
                                        includes: [
+                                         'MilterCore-' + api_version,
                                          'GObject-2.0',
                                        ],
                                        install: true,

--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -80,4 +80,4 @@ milter_client_gir = gnome.generate_gir(libmilter_client,
                                        namespace: 'MilterClient',
                                        nsversion: api_version,
                                        sources: sources + headers + enums,
-                                       symbol_prefix: 'milter')
+                                       symbol_prefix: 'milter_client')

--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -1,0 +1,83 @@
+# Copyright (C) 2022  Daijiro Fukuda <fukuda@clear-code.com>
+# Copyright (C) 2022  Sutou Kouhei <kou@clear-code.com>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+sources = files(
+  'milter-client-context.c',
+  'milter-client-main.c',
+  'milter-client-runner.c',
+  'milter-client-single-thread-runner.c',
+  'milter-client.c',
+)
+
+headers = files(
+  'milter-client-context.h',
+  'milter-client-objects.h',
+  'milter-client-runner.h',
+  'milter-client-single-thread-runner.h',
+  'milter-client.h',
+)
+
+install_headers(headers, subdir: join_paths('milter', 'client'))
+
+enums = gnome.mkenums_simple('milter-client-enum-types',
+                             body_prefix: '#include <config.h>',
+                             identifier_prefix: 'Milter',
+                             install_dir: join_paths('milter', 'client'),
+                             install_header: true,
+                             sources: headers,
+                             symbol_prefix: 'milter')
+
+gobject = dependency('gobject-2.0')
+c_compiler = meson.get_compiler('c')
+ev = declare_dependency(compile_args: '-DEV_COMPAT3=0',
+                        dependencies: c_compiler.find_library('ev'))
+dependencies = [
+  config,
+  gobject,
+  ev,
+]
+milter_client = library('milter-client',
+                        c_args: '-DMILTER_LOG_DOMAIN="milter-client"',
+                        sources: sources + headers + enums,
+                        install: true,
+                        dependencies: dependencies,
+                        soversion: so_version,
+                        version: library_version)
+
+pkgconfig.generate(milter_client,
+                   description: 'milter API',
+                   filebase: 'milter-client',
+                   name: 'milter client library',
+                   requires: ['gobject-2.0'],
+                   variables: pkgconfig_variables,
+                   version: meson.version())
+
+milter_client_gir = gnome.generate_gir(milter_client,
+                                       export_packages: 'milter-client',
+                                       extra_args: [
+                                         '--warn-all',
+                                       ],
+                                       fatal_warnings: true,
+                                       header: 'milter/client.h',
+                                       identifier_prefix: 'Milter',
+                                       includes: [
+                                         'GObject-2.0',
+                                       ],
+                                       install: true,
+                                       namespace: 'MilterClient',
+                                       nsversion: api_version,
+                                       sources: sources + headers + enums,
+                                       symbol_prefix: 'milter')

--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -40,24 +40,19 @@ enums = gnome.mkenums_simple('milter-client-enum-types',
                              sources: headers,
                              symbol_prefix: 'milter')
 
-gobject = dependency('gobject-2.0')
-c_compiler = meson.get_compiler('c')
-ev = declare_dependency(compile_args: '-DEV_COMPAT3=0',
-                        dependencies: c_compiler.find_library('ev'))
 dependencies = [
   config,
-  gobject,
-  ev,
+  milter_core,
 ]
-milter_client = library('milter-client',
-                        c_args: '-DMILTER_LOG_DOMAIN="milter-client"',
-                        sources: sources + headers + enums,
-                        install: true,
-                        dependencies: dependencies,
-                        soversion: so_version,
-                        version: library_version)
+libmilter_client = library('milter-client',
+                           c_args: '-DMILTER_LOG_DOMAIN="milter-client"',
+                           sources: sources + headers + enums,
+                           install: true,
+                           dependencies: dependencies,
+                           soversion: so_version,
+                           version: library_version)
 
-pkgconfig.generate(milter_client,
+pkgconfig.generate(libmilter_client,
                    description: 'milter API',
                    filebase: 'milter-client',
                    name: 'milter client library',
@@ -65,7 +60,7 @@ pkgconfig.generate(milter_client,
                    variables: pkgconfig_variables,
                    version: meson.version())
 
-milter_client_gir = gnome.generate_gir(milter_client,
+milter_client_gir = gnome.generate_gir(libmilter_client,
                                        export_packages: 'milter-client',
                                        extra_args: [
                                          '--warn-all',

--- a/milter/core/meson.build
+++ b/milter/core/meson.build
@@ -109,15 +109,17 @@ dependencies = [
   gobject,
   ev,
 ]
-milter_core = library('milter-core',
-                      c_args: '-DMILTER_LOG_DOMAIN="milter-core"',
-                      sources: sources + headers + enums + marshalers,
-                      install: true,
-                      dependencies: dependencies,
-                      soversion: so_version,
-                      version: library_version)
+libmilter_core = library('milter-core',
+                         c_args: '-DMILTER_LOG_DOMAIN="milter-core"',
+                         sources: sources + headers + enums + marshalers,
+                         install: true,
+                         dependencies: dependencies,
+                         soversion: so_version,
+                         version: library_version)
+milter_core = declare_dependency(link_with: libmilter_core,
+                                 dependencies: dependencies)
 
-pkgconfig.generate(milter_core,
+pkgconfig.generate(libmilter_core,
                    description: 'common milter features',
                    filebase: 'milter-core',
                    name: 'milter core library',
@@ -125,7 +127,7 @@ pkgconfig.generate(milter_core,
                    variables: pkgconfig_variables,
                    version: meson.version())
 
-milter_core_gir = gnome.generate_gir(milter_core,
+milter_core_gir = gnome.generate_gir(libmilter_core,
                                      export_packages: 'milter-core',
                                      extra_args: [
                                        '--warn-all',


### PR DESCRIPTION
This fix tries to build milter-client with Meson as well as https://github.com/milter-manager/milter-manager/pull/159.

Currently I get the following error: `error: ‘GETTEXT_PACKAGE’ undeclared`

```console
$ meson setup --prefix=/tmp/local ../milter-manager.build .
$ ninja -C ../milter-manager.build
(omit)
[1/4] Compiling C object 'milter/client/2b66477@@milter-client@sha/milter-client-main.c.o'.
FAILED: milter/client/2b66477@@milter-client@sha/milter-client-main.c.o 
cc -Imilter/client/2b66477@@milter-client@sha -Imilter/client -I../milter-manager/milter/client -I. -I../milter-manager/ -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -g -fPIC -DEV_COMPAT3=0 -DHAVE_CONFIG_H '-DMILTER_LOG_DOMAIN="milter-client"' -MD -MQ 'milter/client/2b66477@@milter-client@sha/milter-client-main.c.o' -MF 'milter/client/2b66477@@milter-client@sha/milter-client-main.c.o.d' -o 'milter/client/2b66477@@milter-client@sha/milter-client-main.c.o' -c ../milter-manager/milter/client/milter-client-main.c
../milter-manager/milter/client/milter-client-main.c: In function ‘milter_client_get_option_group’:
../milter-manager/milter/client/milter-client-main.c:707:50: error: ‘GETTEXT_PACKAGE’ undeclared (first use in this function)
  707 |     g_option_group_set_translation_domain(group, GETTEXT_PACKAGE);
(omit)
```

I think we need to add the corresponding process for the following part:

* https://github.com/milter-manager/milter-manager/blob/master/configure.ac#L1031-L1033

And I don't understand how I should handle the dependencies of milter-client.

`milter-client.pc.in` says milter-client needs milter-core only.

* https://github.com/milter-manager/milter-manager/blob/master/milter-client.pc.in
