### PR TITLE
Fix to use the project version instead of meson version

### DIFF
--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -56,7 +56,7 @@ pkgconfig.generate(libmilter_client,
                    description: 'milter API',
                    filebase: 'milter-client',
                    name: 'milter client library',
-                   requires: ['milter-core = ' + meson.version()],
+                   requires: ['milter-core = ' + meson.project_version()],
                    variables: pkgconfig_variables,
                    version: meson.version())
 

--- a/milter/core/meson.build
+++ b/milter/core/meson.build
@@ -77,8 +77,8 @@ headers = files(
 )
 
 version_h_conf = configuration_data()
-version_components = meson.version().split('.')
-version_h_conf.set('MILTER_MANAGER_VERSION', meson.version())
+version_components = meson.project_version().split('.')
+version_h_conf.set('MILTER_MANAGER_VERSION', meson.project_version())
 version_h_conf.set('MILTER_MANAGER_VERSION_MAJOR', version_components[0])
 version_h_conf.set('MILTER_MANAGER_VERSION_MINOR', version_components[1])
 version_h_conf.set('MILTER_MANAGER_VERSION_MICRO', version_components[2])


### PR DESCRIPTION
The Meson version is wrongly used now.

We have to use the project version here.