### PR TITLE
Use the project version for pkgconfig instead of meson version

### DIFF
--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -59,8 +59,7 @@ pkgconfig.generate(libmilter_client,
                    filebase: 'milter-client',
                    name: 'milter client library',
                    requires: ['milter-core = ' + meson.project_version()],
-                   variables: pkgconfig_variables,
-                   version: meson.version())
+                   variables: pkgconfig_variables)
 
 dependencies = [
   declare_dependency(sources: milter_core_gir),

--- a/milter/core/meson.build
+++ b/milter/core/meson.build
@@ -123,8 +123,7 @@ pkgconfig.generate(libmilter_core,
                    filebase: 'milter-core',
                    name: 'milter core library',
                    requires: ['gobject-2.0'],
-                   variables: pkgconfig_variables,
-                   version: meson.version())
+                   variables: pkgconfig_variables)
 
 milter_core_gir = gnome.generate_gir(libmilter_core,
                                      export_packages: 'milter-core',


### PR DESCRIPTION
We must use `meson.project_version()` here,
but we can omit the `version` option to use the project version.

https://mesonbuild.com/Pkgconfig-module.html#pkggenerate