### PR TITLE
Fix install_dir for Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ so_version = 2
 library_version = '@0@.0.0'.format(so_version)
 
 prefix = get_option('prefix')
-include_dir = join_paths(prefix, get_option('includedir'))
+include_dir = join_paths(get_option('includedir'), meson.project_name())
 data_dir = join_paths(prefix, get_option('datadir'))
 gir_dir = join_paths(data_dir, 'gir-1.0')
 

--- a/milter/client/meson.build
+++ b/milter/client/meson.build
@@ -33,13 +33,13 @@ headers = files(
 enums = gnome.mkenums_simple('milter-client-enum-types',
                              body_prefix: '#include <config.h>',
                              identifier_prefix: 'Milter',
-                             install_dir: join_paths('milter', 'client'),
+                             install_dir: join_paths(include_dir, 'milter', 'client'),
                              install_header: true,
                              sources: headers,
                              symbol_prefix: 'milter')
 
-install_headers(headers, subdir: join_paths('milter', 'client'))
-install_headers(['../client.h'], subdir: join_paths('milter'))
+install_headers(headers, subdir: join_paths(include_dir, 'milter', 'client'))
+install_headers(['../client.h'], subdir: join_paths(include_dir, 'milter'))
 headers += ['../client.h']
 
 dependencies = [

--- a/milter/core/meson.build
+++ b/milter/core/meson.build
@@ -90,13 +90,13 @@ headers += version_h
 enums = gnome.mkenums_simple('milter-enum-types',
                              body_prefix: '#include <config.h>',
                              identifier_prefix: 'Milter',
-                             install_dir: join_paths('milter', 'core'),
+                             install_dir: join_paths(include_dir, 'milter', 'core'),
                              install_header: true,
                              sources: headers,
                              symbol_prefix: 'milter')
 
-install_headers(headers, subdir: join_paths('milter', 'core'))
-install_headers(['../core.h'], subdir: join_paths('milter'))
+install_headers(headers, subdir: join_paths(include_dir, 'milter', 'core'))
+install_headers(['../core.h'], subdir: join_paths(include_dir, 'milter'))
 headers += ['../core.h']
 
 gobject = dependency('gobject-2.0')

--- a/milter/server/meson.build
+++ b/milter/server/meson.build
@@ -26,13 +26,13 @@ headers = files(
 enums = gnome.mkenums_simple('milter-server-enum-types',
                              body_prefix: '#include <config.h>',
                              identifier_prefix: 'Milter',
-                             install_dir: join_paths('milter', 'server'),
+                             install_dir: join_paths(include_dir, 'milter', 'server'),
                              install_header: true,
                              sources: headers,
                              symbol_prefix: 'milter')
 
-install_headers(headers, subdir: join_paths('milter', 'server'))
-install_headers(['../server.h'], subdir: join_paths('milter'))
+install_headers(headers, subdir: join_paths(include_dir, 'milter', 'server'))
+install_headers(['../server.h'], subdir: join_paths(include_dir, 'milter'))
 headers += ['../server.h']
 
 dependencies = [


### PR DESCRIPTION
Add `milter-manager` to the path: `${PREFIX}/include/milter-manager`.

For example, use `${PREFIX}/include/milter-manager/milter/client` for `milter/client`'s install_dir.
