### PR TITLE
meson: support Ubuntu focal again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -176,15 +176,14 @@ subdir('milter/client')
 subdir('milter/server')
 subdir('milter/manager')
 subdir('libmilter')
-libruby = dependency('ruby-3.2', 'ruby-3.1', 'ruby-3.0', 'ruby-2.7', 'ruby',
-                     required: true)
+libruby = dependency('ruby', required: true)
 ruby_install_dir = get_option('ruby-install-dir')
 if ruby_install_dir == 'site'
-  ruby_install_dir = libruby.get_variable('sitelibdir')
+  ruby_install_dir = libruby.get_variable(pkgconfig: 'sitelibdir')
 elif ruby_install_dir == 'vendor'
-  ruby_install_dir = libruby.get_variable('vendorlibdir')
+  ruby_install_dir = libruby.get_variable(pkgconfig: 'vendorlibdir')
 endif
-ruby = find_program(libruby.get_variable('ruby'), required: true)
+ruby = find_program(libruby.get_variable(pkgconfig: 'ruby'), required: true)
 rb_glib2_gem_path = \
   run_command(ruby,
               '-e',

--- a/meson.build
+++ b/meson.build
@@ -196,26 +196,12 @@ else
 endif
 
 ruby_install_dir = get_option('ruby-install-dir')
-
-if meson.version().version_compare('>=0.58.0')
-  if ruby_install_dir == 'site'
-    ruby_install_dir = libruby.get_variable('sitelibdir')
-  elif ruby_install_dir == 'vendor'
-    ruby_install_dir = libruby.get_variable('vendorlibdir')
-  endif
-  ruby = find_program(libruby.get_variable('ruby'), required: true)
-else
-  # dep.get_variable():
-  # Before 0.58.0 `varname` was not implemented.
-  # https://mesonbuild.com/Reference-manual_returned_dep.html#depget_variable
-  if ruby_install_dir == 'site'
-    ruby_install_dir = libruby.get_variable(pkgconfig: 'sitelibdir')
-  elif ruby_install_dir == 'vendor'
-    ruby_install_dir = libruby.get_variable(pkgconfig: 'vendorlibdir')
-  endif
-  ruby = find_program(libruby.get_variable(pkgconfig: 'ruby'), required: true)
+if ruby_install_dir == 'site'
+  ruby_install_dir = libruby.get_variable(pkgconfig: 'sitelibdir')
+elif ruby_install_dir == 'vendor'
+  ruby_install_dir = libruby.get_variable(pkgconfig: 'vendorlibdir')
 endif
-
+ruby = find_program(libruby.get_variable(pkgconfig: 'ruby'), required: true)
 rb_glib2_gem_path = \
   run_command(ruby,
               '-e',

--- a/meson.build
+++ b/meson.build
@@ -176,7 +176,16 @@ subdir('milter/client')
 subdir('milter/server')
 subdir('milter/manager')
 subdir('libmilter')
-libruby = dependency('ruby', required: true)
+
+foreach ruby: ['ruby-3.2', 'ruby-3.1', 'ruby-3.0', 'ruby-2.7', 'ruby']
+  libruby = dependency(ruby, required: false)
+  if libruby.found()
+    break
+  endif
+endforeach
+if not libruby.found()
+  error('Ruby not found.')
+endif
 ruby_install_dir = get_option('ruby-install-dir')
 if ruby_install_dir == 'site'
   ruby_install_dir = libruby.get_variable(pkgconfig: 'sitelibdir')

--- a/meson.build
+++ b/meson.build
@@ -177,22 +177,45 @@ subdir('milter/server')
 subdir('milter/manager')
 subdir('libmilter')
 
-foreach ruby: ['ruby-3.2', 'ruby-3.1', 'ruby-3.0', 'ruby-2.7', 'ruby']
-  libruby = dependency(ruby, required: false)
-  if libruby.found()
-    break
+if meson.version().version_compare('>=0.60.0')
+  libruby = dependency('ruby-3.2', 'ruby-3.1', 'ruby-3.0', 'ruby-2.7', 'ruby',
+                       required: true)
+else
+  # depencency():
+  # Before 0.60.0 only a single dependency name was allowed.
+  # https://mesonbuild.com/Reference-manual_functions.html#dependency
+  foreach ruby: ['ruby-3.2', 'ruby-3.1', 'ruby-3.0', 'ruby-2.7', 'ruby']
+    libruby = dependency(ruby, required: false)
+    if libruby.found()
+      break
+    endif
+  endforeach
+  if not libruby.found()
+    error('Ruby not found.')
   endif
-endforeach
-if not libruby.found()
-  error('Ruby not found.')
 endif
+
 ruby_install_dir = get_option('ruby-install-dir')
-if ruby_install_dir == 'site'
-  ruby_install_dir = libruby.get_variable(pkgconfig: 'sitelibdir')
-elif ruby_install_dir == 'vendor'
-  ruby_install_dir = libruby.get_variable(pkgconfig: 'vendorlibdir')
+
+if meson.version().version_compare('>=0.58.0')
+  if ruby_install_dir == 'site'
+    ruby_install_dir = libruby.get_variable('sitelibdir')
+  elif ruby_install_dir == 'vendor'
+    ruby_install_dir = libruby.get_variable('vendorlibdir')
+  endif
+  ruby = find_program(libruby.get_variable('ruby'), required: true)
+else
+  # dep.get_variable():
+  # Before 0.58.0 `varname` was not implemented.
+  # https://mesonbuild.com/Reference-manual_returned_dep.html#depget_variable
+  if ruby_install_dir == 'site'
+    ruby_install_dir = libruby.get_variable(pkgconfig: 'sitelibdir')
+  elif ruby_install_dir == 'vendor'
+    ruby_install_dir = libruby.get_variable(pkgconfig: 'vendorlibdir')
+  endif
+  ruby = find_program(libruby.get_variable(pkgconfig: 'ruby'), required: true)
 endif
-ruby = find_program(libruby.get_variable(pkgconfig: 'ruby'), required: true)
+
 rb_glib2_gem_path = \
   run_command(ruby,
               '-e',


### PR DESCRIPTION
This fix is for Meson 0.53.2 of Ubuntu focal.

`dependency()`:

* I got the error: `meson.build:179:0: ERROR: Expected 1 arguments, got 5.`
* More than one name can be provided since 0.60.0
* https://mesonbuild.com/Reference-manual_functions.html#dependency

`dep.get_variable()`:

* I got the error: `meson.build:183:2: ERROR: Function does not take positional arguments.`
* `varname` is since 0.58.0
* https://mesonbuild.com/Reference-manual_returned_dep.html#depget_variable
