### PR TITLE
python logger: support Python 3.8

### DIFF
--- a/binding/python/gi/overrides/MilterCore/logger.py
+++ b/binding/python/gi/overrides/MilterCore/logger.py
@@ -70,7 +70,10 @@ def log(self, level, message, n_call_depth=None):
         message = ""
     elif isinstance(message, Exception):
         output = io.StringIO()
-        traceback.print_exception(message, file=output)
+        traceback.print_exception(type(message),
+                                  message,
+                                  message.__traceback__,
+                                  file=output)
         message = output.getvalue()
     else:
         message = str(message)


### PR DESCRIPTION
The signature of `traceback.print_exception` changed at Python 3.10:

* https://docs.python.org/ja/3/library/traceback.html#traceback.print_exception
* https://docs.python.org/ja/3.8/library/traceback.html#traceback.print_exception

For example, the following code is valid for Python 3.10, but invalid for Python 3.8.

```py
import traceback
import io

e = Exception("hoge")
output = io.StringIO()
traceback.print_exception(e, file=output)
message = output.getvalue()
message
```

This causes the following error with Python 3.8.10:

```
      1 output = io.StringIO()
----> 2 traceback.print_exception(e,file=output)
      3 message = output.getvalue()
      4 message

TypeError: print_exception() missing 2 required positional arguments: 'value' and 'tb'
```

This is also a problem when using fallback_status.

According to the documentation mentioned above, the previous signature before 3.10 is compatible with 3.10,
so we can use that to support Python 3.8.

Python 3.10.4

```py
import traceback
import io

e = Exception("hoge")
output = io.StringIO()
traceback.print_exception(type(e), e, e.__traceback__, file=output)
message = output.getvalue()
message
=> 'Exception: hoge\n'
```
