### PR TITLE
python: simplify milter samples

### DIFF
--- a/binding/python/sample/milter-external.py
+++ b/binding/python/sample/milter-external.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import re
 import subprocess
 import sys
 
@@ -33,7 +32,7 @@ class MilterExternal(milter.client.Session):
         command_line = [
             sys.executable,
             "-c",
-            f"import random; import time; time.sleep({self._timeout})",
+            f"import time; time.sleep({self._timeout})",
         ]
         process = subprocess.Popen(command_line)
         def on_exit(pid, wait_status):
@@ -45,7 +44,7 @@ class MilterExternal(milter.client.Session):
         self._delay_response()
 
     def abort(self, status):
-        if not self._source_id is None:
+        if self._source_id is not None:
             self._remove_source(self._source_id)
 
     def reset(self):

--- a/binding/python/sample/milter-replace.py
+++ b/binding/python/sample/milter-replace.py
@@ -37,7 +37,7 @@ class MilterReplace(milter.client.Session):
     def end_of_message(self):
         header_indexes = {}
         for name, value in self._headers:
-            if not name in header_indexes:
+            if name not in header_indexes:
                 header_indexes[name] = 0
             header_indexes[name] += 1
             for pattern, replaced in self._patterns.items():


### PR DESCRIPTION
I found some needless codes.

In addition, I refactored some code shapes.

https://peps.python.org/pep-0008/#programming-recommendations
(`is not`  is mentioned, but there doesn't seem to be any specific mention of `A not in B`...
However, I often see `A not in B` than `not A in B`)
