### PR TITLE
set use_bytes on ruby milter client

### DIFF
--- a/binding/ruby/lib/milter/client.rb
+++ b/binding/ruby/lib/milter/client.rb
@@ -143,6 +143,7 @@ module Milter
 
     private
     def setup_session(context, session_class, session_new_arguments)
+      context.set_use_bytes(true)
       session_context = ClientSessionContext.new(context)
       session = session_class.new(session_context, *session_new_arguments)
 
@@ -152,6 +153,8 @@ module Milter
         next unless session.respond_to?(event)
         if event == :body
           signal = "body-bytes"
+        elsif event == :end_of_message
+          signal = "end_of_message_bytes"
         else
           signal = event
         end

--- a/binding/ruby/lib/milter/client.rb
+++ b/binding/ruby/lib/milter/client.rb
@@ -143,7 +143,7 @@ module Milter
 
     private
     def setup_session(context, session_class, session_new_arguments)
-      context.set_use_bytes(true)
+      context.use_bytes = true
       session_context = ClientSessionContext.new(context)
       session = session_class.new(session_context, *session_new_arguments)
 


### PR DESCRIPTION
body-bytes was disabled by not setting set_use_bytes(true) in client.rb.
I also had to replace end_of_message with end_of_message_bytes.
<pre>
/**
 * milter_client_context_set_use_bytes:
 * @context: A #MilterClientContext.
 * @use: Whether #MilterClientContext::body-bytes and
 *   #MilterClientContext::end-of-message-bytes are used instead of
 *   #MilterClientContext::body and
 *   #MilterClientContext::end-of-message.
 *
 * Since: 2.1.6
 */
</pre>