### PR TITLE
ci test: use Docker Compose v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             --location \
             https://raw.github.com/clear-code/cutter/master/data/travis/setup.sh | sh
       - run: ./autogen.sh
-      - run: docker-compose build ${{ matrix.service }}
+      - run: docker compose build ${{ matrix.service }}
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -44,7 +44,7 @@ jobs:
         run: |
           sudo mkdir -p .cache/ccache/
           sudo chmod -R o+rwx .cache/ccache/
-      - run: docker-compose run --rm ${{ matrix.service }}
+      - run: docker compose run --rm ${{ matrix.service }}
 
   # Temporary. We should integrate this to the above test job.
   meson:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   # TODO
   almalinux-8:


### PR DESCRIPTION
Docker Compose v1 is not supported on GitHub runners:

https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/