### PR TITLE
ci test: use ubuntu-22.04 for cutter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-bionic
           - ubuntu-focal
           - ubuntu-jammy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`cutter-testing-framework` is not provided for Noble yet. The current CI fails as follows:

    The repository 'https://ppa.launchpadcontent.net/cutter-testing-framework/ppa/ubuntu
    noble Release' does not have a Release file.