### PR TITLE
ci test: fix failing Debian Bookworm tests

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -45,6 +45,21 @@ services:
     command:
       /host/dockerfiles/run-test.sh
 
+  debian-bookworm:
+    build:
+      context: .
+      dockerfile: dockerfiles/debian-bookworm.dockerfile
+    environment:
+      TZ: Asia/Tokyo
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - "seccomp=unconfined"
+    volumes:
+      - .:/host:delegated
+    command:
+      /host/dockerfiles/run-test.sh
+
   ubuntu-bionic:
     build:
       context: .

--- a/dockerfiles/debian-bookworm.dockerfile
+++ b/dockerfiles/debian-bookworm.dockerfile
@@ -1,0 +1,34 @@
+FROM debian:bookworm
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+RUN apt update && \
+    apt install -qq -y \
+      ccache \
+      curl \
+      git \
+      gtk-doc-tools \
+      intltool \
+      libev-dev \
+      libgirepository1.0-dev \
+      libglib2.0-dev \
+      libtool \
+      lsb-release \
+      rrdtool \
+      ruby \
+      ruby-dev \
+      ruby-gnome-dev \
+      ruby-test-unit \
+      sudo \
+      tzdata && \
+    curl -L https://raw.github.com/clear-code/cutter/master/data/travis/setup.sh | CUTTER_MASTER=yes sh
+
+ENV PATH=/usr/lib/ccache:$PATH
+
+RUN useradd -m --user-group --shell /bin/bash milter-manager
+RUN mkdir /build && \
+    chown -R milter-manager: /build
+
+USER milter-manager


### PR DESCRIPTION
In 37785834dc36de0372cd03378d495683293d4352, the setting for `compose.yaml` was missing.

