### PR TITLE
ci package: fix build error

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -141,8 +141,8 @@ jobs:
             target: almalinux-9
             test-docker-image: almalinux:9
     env:
-      APACHE_ARROW_REPOSITORY: apache-arrow
-      GROONGA_REPOSITORY: groonga
+      APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
+      GROONGA_REPOSITORY: ${{ github.workspace }}/groonga
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
The paths of these repo were wrong since eb62d47542f8c150b1d83ba1cf39c87e2d34aaa2.

They should be absolute because of `cd` before the `rake version:update`.

The error occurs in:

    cd package
    rake version:update RELEASE_DATE=$(date +%Y-%m-%d)

The content of the error:

     rake aborted!
     LoadError: cannot load such file -- groonga/packages/packages-groonga-org-package-task
     <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'
     <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'
     /home/runner/work/milter-manager/milter-manager/package/Rakefile:21:in `<top (required)>'